### PR TITLE
added ability to set initial active tab

### DIFF
--- a/docs/api/tabs.md
+++ b/docs/api/tabs.md
@@ -48,6 +48,11 @@ The `<Tabs>` component pass every props given to the containing `<Box>` of the t
 
 If you specify a `width` to `<Tabs flexDirection="column"`, the width will be used to force the separator width.
 
+### **initialActiveTab**
+
+The first tab is active by default on component mount, you can choose another tab by setting
+`initialActiveTab` to the index of it.
+
 ## **Focus management**
 
 The `Tabs` accept a `isFocused` prop to handle focus management by an external source.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,6 +49,7 @@ export interface TabsProps {
   width?: BoxProps['width'];
   keyMap?: KeyMapProps;
   isFocused?: boolean;
+  initialActiveTab?: number;
 }
 interface TabsWithStdinProps extends TabsProps {
   isRawModeSupported: boolean;
@@ -71,6 +72,7 @@ class TabsWithStdin extends React.Component<
     flexDirection: 'row',
     keyMap: null,
     isFocused: null, // isFocused is null mean that the focus not handle by ink
+    initialActiveTab: 0,
   };
 
   constructor(props: TabsWithStdinProps) {
@@ -94,7 +96,13 @@ class TabsWithStdin extends React.Component<
   }
 
   componentDidMount(): void {
-    const { stdin, setRawMode, isRawModeSupported } = this.props;
+    const {
+      stdin,
+      setRawMode,
+      isRawModeSupported,
+      children,
+      initialActiveTab,
+    } = this.props;
 
     if (isRawModeSupported && stdin) {
       // use ink / node `setRawMode` to read key-by-key
@@ -106,8 +114,12 @@ class TabsWithStdin extends React.Component<
       stdin.on('keypress', this.handleKeyPress);
     }
 
-    // select the first tab on component mount
-    this.handleTabChange(0);
+    // select initialActiveTab if it's valid otherwise select the first tab on component mount
+    if (initialActiveTab && children[initialActiveTab]) {
+      this.handleTabChange(initialActiveTab);
+    } else {
+      this.handleTabChange(0);
+    }
   }
 
   componentWillUnmount(): void {


### PR DESCRIPTION
added `initialActiveTab` property to the Tabs component, in order to be able set initial active tab other than first one